### PR TITLE
security: disable tinyproxy to close squid whitelist bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## Unreleased
+
+### Security
+- **Disabled tinyproxy (`playbooks/proxy.yaml`) in `main.yml`.** It listened on
+  `localhost:8888` and forwarded to any destination with no domain whitelist.
+  Because the UFW rules allow `127.0.0.1 -> 127.0.0.1`, a contestant could set
+  `http_proxy=http://localhost:8888` and reach arbitrary sites, bypassing the
+  squid allow-list that is supposed to be the network filter. squid
+  (`playbooks/firewall.yml`) remains the single egress filter.
+
+### Known issues / follow-ups (not changed here)
+- `configs/imageadmin-ssh_key` is a committed private key. It is only used to
+  talk to the local QEMU build VM and `imageadmin` is removed from the final
+  image by `files/scripts/makeDist.sh`, so it does not ship — but it is still a
+  private key in version control.
+- `files/scripts/firewall.sh` / `playbooks/firewall.yaml` are an older
+  UFW-only approach (with `ufw default deny outgoing`) that is **not** wired
+  into `main.yml`. They are dead code today and would break squid-based egress
+  if run by accident; consider removing them to avoid confusion.

--- a/main.yml
+++ b/main.yml
@@ -100,7 +100,13 @@
     - import_tasks: 'playbooks/gui.yml'
 
     - import_tasks: 'playbooks/reverseproxy.yml'
-    - import_tasks: 'playbooks/proxy.yaml'
+    # NOTE: proxy.yaml (tinyproxy on :8888) is intentionally disabled.
+    # squid (playbooks/firewall.yml) is the network filter. tinyproxy forwards to
+    # ANY destination with no domain whitelist, and the UFW rules allow
+    # 127.0.0.1->127.0.0.1, so a contestant pointing http_proxy at localhost:8888
+    # would bypass the squid allow-list entirely. Re-enable only if it is chained
+    # behind squid.
+    #- import_tasks: 'playbooks/proxy.yaml'
     - import_tasks: 'playbooks/compilers.yml'
     - import_tasks: 'playbooks/devel_tools.yml'
   #  - import_tasks: 'roles/jetbrains_ides/tasks/main.yml'


### PR DESCRIPTION
## Problem
`main.yml` installs **both** squid (the intended domain-whitelist filter on `:3128`) and tinyproxy (`playbooks/proxy.yaml`, on `:8888`), but never chains them. tinyproxy forwards to **any** destination with no whitelist, and the UFW rules allow `127.0.0.1 -> 127.0.0.1`. A contestant can therefore set `http_proxy=http://localhost:8888` and reach arbitrary sites, **bypassing the squid allow-list** that is supposed to be the network filter.

## Fix
Disable the `proxy.yaml` import so squid is the single egress filter. Adds a `CHANGELOG.md` documenting this plus two related follow-ups (committed `imageadmin-ssh_key`, dead `firewall.sh`/`firewall.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)