### PR TITLE
vscode: install vim/emacs but disable them by default

### DIFF
--- a/group_vars/all.dist
+++ b/group_vars/all.dist
@@ -58,6 +58,10 @@ vscode_extensions:
   # Java
   - vscjava.vscode-java-pack
   # Misc
+  # vim/emacs keybinding extensions are installed but DISABLED by default
+  # (see vscode_disabled_by_default below): they remap the editor's keybindings,
+  # which has repeatedly confused contestants who don't use them. A contestant who
+  # wants vim/emacs just enables it in the Extensions view.
   - vscodevim.vim
   - lfs.vscode-emacs-friendly
   # Themes
@@ -65,6 +69,14 @@ vscode_extensions:
   - akamud.vscode-theme-onelight
   - tgreen7.one-monokai-dark
   - jprestidge.theme-material-theme
+
+# Extensions that are installed (from vscode_extensions) but DISABLED by default.
+# Contestants can turn them on in the Extensions view. Use this for extensions that
+# change editor behaviour for everyone (e.g. remapping keybindings) and so shouldn't
+# be forced on by default. Entries not present in vscode_extensions are ignored.
+vscode_disabled_by_default:
+  - vscodevim.vim
+  - lfs.vscode-emacs-friendly
 
 # Firefox policies. Documented here:
 # https://mozilla.github.io/policy-templates/

--- a/playbooks/devel_tools/vscode.yaml
+++ b/playbooks/devel_tools/vscode.yaml
@@ -16,6 +16,39 @@
   shell: code --extensions-dir /opt/vscode/extensions --user-data-dir /opt/vscode --no-sandbox --install-extension {{ item }}
   loop: "{{ vscode_extensions }}"
 
+# Some extensions (e.g. vim/emacs keybindings) change the editor for everyone and
+# shouldn't be forced on. We keep them installed but seed VS Code's per-user
+# disabled-extensions list into /etc/skel so they are OFF by default; a contestant
+# who wants one just enables it in the Extensions view. /etc/skel is the seed for
+# every contestant created with `useradd -m` (incl. deleteUser.sh resets).
+- name: compute which installed extensions to disable by default
+  set_fact:
+    vscode_disabled_effective: "{{ vscode_disabled_by_default | default([]) | intersect(vscode_extensions) }}"
+
+- name: seed VS Code disabled-extensions defaults into skel (installed but off)
+  when: vscode_disabled_effective | length > 0
+  shell: |
+    python3 - <<'PY'
+    import json, os, sqlite3
+    ids = "{{ vscode_disabled_effective | join(' ') }}".split()
+    base = "/etc/skel/.config/Code/User/globalStorage"
+    os.makedirs(base, exist_ok=True)
+    disabled = [{"id": i} for i in ids]
+    value = json.dumps(disabled)
+    # Legacy JSON store (older VS Code builds read this).
+    with open(os.path.join(base, "storage.json"), "w") as f:
+        json.dump({"extensionsIdentifiers/disabled": disabled}, f)
+    # Current SQLite store (state.vscdb) used by recent VS Code builds.
+    con = sqlite3.connect(os.path.join(base, "state.vscdb"))
+    con.execute("CREATE TABLE IF NOT EXISTS ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)")
+    con.execute("INSERT OR REPLACE INTO ItemTable (key, value) VALUES (?, ?)",
+                ("extensionsIdentifiers/disabled", value))
+    con.commit()
+    con.close()
+    PY
+  args:
+    executable: /bin/bash
+
 - name: create a script to symlink our extensions
   copy:
     dest: /usr/local/bin/vscode-extension-install


### PR DESCRIPTION
## What

The `vscodevim.vim` and `lfs.vscode-emacs-friendly` extensions remap VS Code's keybindings for **every** contestant once installed, which has repeatedly confused contestants who don't use vim/emacs.

This **keeps both extensions installed** but makes them **disabled by default**, so the default editing experience is stock VS Code while contestants who want vim/emacs can turn them on with one click in the Extensions view.

## How

- `group_vars/all.dist`: restores `vscodevim.vim` / `lfs.vscode-emacs-friendly` to `vscode_extensions`, and adds a documented `vscode_disabled_by_default` list.
- `playbooks/devel_tools/vscode.yaml`: after installing extensions, seeds VS Code's per-user disabled-extensions list into `/etc/skel/.config/Code/User/globalStorage` (the intersection of `vscode_disabled_by_default` and the installed set). `/etc/skel` is the seed for every contestant created with `useradd -m`, including `deleteUser.sh` resets. Both the legacy `storage.json` and the current `state.vscdb` stores are written for cross-version robustness.

## Verify

On the built image, create/reset a contestant, launch VS Code → Extensions view shows **Vim** and the emacs extension as *installed but Disabled*; editing is normal; clicking **Enable** + reload turns vim mode on.