### PR TITLE
build: stop running every language playbook twice, and speed up the build VM

### DIFF
--- a/build-final.sh
+++ b/build-final.sh
@@ -11,6 +11,13 @@ SSH_ICPCADMIN_KEY="files/secrets/icpcadmin@contestmanager"
 PIDFILE="tmp/qemu.pid"
 ALIVE=0
 
+# Resources for the build VM. The provisioning run is mostly apt/dpkg and archive
+# extraction, so giving it more than one core and more than 1G of RAM cuts a large
+# chunk off the build time. Override from the environment on smaller build hosts,
+# e.g. SMP=2 MEM=2048 ./build-final.sh
+SMP=${SMP:-$(nproc)}
+MEM=${MEM:-4096}
+
 IMGFILE="output/$(date +%Y-%m-%d)_image-amd64.img"
 if [[ $IMGFILE != 'all' ]]; then
   IMGFILE="output/$VARIANT-$(date +%Y-%m-%d)_image-amd64.img"
@@ -65,7 +72,7 @@ function waitforssh() {
   fi
 }
 
-qemu-system-x86_64 -smp 1 -m 1024 -drive file="$IMGFILE",index=0,media=disk,format=raw --enable-kvm -net user,hostfwd=tcp::$SSHPORT-:22 -net nic --daemonize --pidfile $PIDFILE -vnc :0 -vga qxl -spice port=5901,disable-ticketing=on -usbdevice tablet -cpu host
+qemu-system-x86_64 -smp $SMP -m $MEM -drive file="$IMGFILE",index=0,media=disk,format=raw --enable-kvm -netdev user,id=vnet,ipv6=off,hostfwd=tcp::$SSHPORT-:22 -device virtio-net-pci,netdev=vnet --daemonize --pidfile $PIDFILE -vnc :0 -vga qxl -spice port=5901,disable-ticketing=on -usbdevice tablet -cpu host
 #qemu-system-x86_64 -smp 1 -m 1024 -drive file="$IMGFILE",index=0,media=disk,format=raw -global isa-fdc.driveA= --enable-kvm -net user,hostfwd=tcp::$SSHPORT-:22 -net nic --daemonize --pidfile $PIDFILE -vnc :0 -vga qxl -spice port=5901,disable-ticketing -usbdevice tablet
 
 ALIVE=0

--- a/playbooks/compilers.yml
+++ b/playbooks/compilers.yml
@@ -29,10 +29,4 @@
     loop: "{{ lang_docs | dict2items }}"
 
   - name: create simple index page for links to docs
-    template: src=files/language-docs.html.j2 dest=/opt/localwww/index.html  
-    
-  - name: include various languages
-    include_tasks: "languages/{{ language }}.yml"
-    loop: "{{ languages }}"
-    loop_control:
-      loop_var: language
+    template: src=files/language-docs.html.j2 dest=/opt/localwww/index.html


### PR DESCRIPTION
Picking up #23 (Reduce Built Time).

## The main one: every language playbook runs twice

`playbooks/compilers.yml` includes the languages loop **twice**. The duplicate came in with 9d60d5a (Sep 2023), which added the `lang_docs` fact and the docs-index block *above* the existing loop but never removed the original loop at the bottom — it was only renamed `.yaml` → `.yml`, which is why it went unnoticed in review.

So for the last ~2 years every entry in `languages:` has been provisioned twice per build: each one repeats its apt installs, `add-apt-repository` calls, `update_cache` refreshes and doc downloads, for no effect on the resulting image. With `c`, `cpp`, `java`, `python3` enabled that is a lot of duplicated apt traffic — and apt traffic is precisely what #23 identifies as the bottleneck.

Ordering is preserved: languages are still included before the docs symlinks and index page are generated, so `lang_docs` is fully populated when it is consumed.

## Build VM resources

`build-final.sh` pinned the provisioning VM to `-smp 1 -m 1024`, while `runvm.sh` already used `-smp 2 -m 4096`. The ansible run is mostly apt/dpkg and archive extraction, which one core and 1G of RAM throttle badly. Now defaults to `$(nproc)` / 4096, overridable for smaller build hosts:

```sh
SMP=2 MEM=2048 ./build-final.sh
```

## Network configuration

Applies the same modernisation @panmegas04 made to `create_baseimg.sh` in 96c7a48 — legacy `-net nic -net user,...` → `-netdev` + `-device virtio-net-pci` — so the two scripts stay consistent and `build-final.sh` doesn't keep the legacy `-net` handling that was getting builds stuck.

Interface naming is unaffected: `net.ifnames=0` is set both in `configs/2204_autoinstall.yaml` and `playbooks/system.yml`, so the NIC stays `eth0` and still matches the `name: e*` rule in `files/01-netcfg.yaml`.

## Testing

Static checks only so far — `bash -n` on `build-final.sh`, and the resulting `compilers.yml` parses with exactly one `include_tasks` and the task order intact. **I have not run a full `build-final.sh` end to end**, so a timing comparison from someone with a build host would be worth having before merge. The compilers.yml change is a pure deletion of a redundant loop, so the risk is mostly in the qemu flags.

Note this does *not* implement download retention/caching, which is the other half of #23 — the artifact-caching side is still open.

Refs #23